### PR TITLE
 Update array syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     ggplot2 (>= 3.3.2),
     metRology (>= 0.9.28.1),
     reshape (>= 0.8.8),
-    rstan (>= 2.21.2),
+    rstan (>= 2.26.0),
     rstantools (>= 2.1.1),
     mcmcse (>= 1.4.1),
     stats (>= 4.0.0),
@@ -35,8 +35,8 @@ Suggests:
     rmarkdown (>= 2.5.0),
     knitr (>= 1.30.0)
 LinkingTo:
-    StanHeaders (>= 2.21.0.6),
-    rstan (>= 2.21.0),
+    StanHeaders (>= 2.26.0),
+    rstan (>= 2.26.0),
     BH (>= 1.72.0.3),
     Rcpp (>= 1.0.5),
     RcppEigen (>= 0.3.3.7.0),

--- a/inst/stan/color.stan
+++ b/inst/stan/color.stan
@@ -1,17 +1,17 @@
 data {
 	int<lower=0> n; // number of data entries
 	// rgb
-	real<lower=0,upper=255> r[n];
-	real<lower=0,upper=255> g[n];
-	real<lower=0,upper=255> b[n];
+	array[n] real<lower=0,upper=255> r;
+	array[n] real<lower=0,upper=255> g;
+	array[n] real<lower=0,upper=255> b;
 	// hsv
-	real<lower=0,upper=2*pi()> h[n];
-	real<lower=0,upper=1> s[n];
-	real<lower=0,upper=1> v[n];
+	array[n] real<lower=0,upper=2*pi()> h;
+	array[n] real<lower=0,upper=1> s;
+	array[n] real<lower=0,upper=1> v;
 
 	// priors
-	int<lower=0> p_ids[12];
-	real p_values[24];
+	array[12] int<lower=0> p_ids;
+	array[24] real p_values;
 }
 
 parameters {

--- a/inst/stan/linear.stan
+++ b/inst/stan/linear.stan
@@ -3,11 +3,11 @@ data {
   int<lower=0> m; // number of subjects
   vector[n] x; // sequence/time
   vector[n] y; // response
-  int<lower=0> s[n]; // subject ids
+  array[n] int<lower=0> s; // subject ids
 
   // priors
-  int<lower=0> p_ids[6];
-  real p_values[12];
+  array[6] int<lower=0> p_ids;
+  array[12] real p_values;
 }
 
 parameters {

--- a/inst/stan/reaction_time.stan
+++ b/inst/stan/reaction_time.stan
@@ -2,11 +2,11 @@ data {
   int<lower=0> n; // total number of measurements
   int<lower=0> m; // number of subjects
   vector<lower=0>[n] t; // reaction times
-  int<lower=0> s[n]; // subject ids
+  array[n] int<lower=0> s; // subject ids
 
   // priors
-  int p_ids[6];
-  real p_values[12];
+  array[6] int p_ids;
+  array[12] real p_values;
 }
 
 parameters {

--- a/inst/stan/success_rate.stan
+++ b/inst/stan/success_rate.stan
@@ -1,12 +1,12 @@
 data {
   int<lower=0> n; // total number of measurements
   int<lower=0> m; // number of subjects
-  int<lower=0,upper=1> r[n]; // results - success or fail
-  int<lower=0> s[n]; // subject ids
+  array[n] int<lower=0,upper=1> r; // results - success or fail
+  array[n] int<lower=0> s; // subject ids
 
   // priors
-  int<lower=0> p_ids[2];
-  real<lower=0> p_values[4];
+  array[2] int<lower=0> p_ids;
+  array[4] real<lower=0> p_values;
 }
 
 parameters {

--- a/inst/stan/ttest.stan
+++ b/inst/stan/ttest.stan
@@ -1,10 +1,10 @@
 data {
   int<lower=0> n; // number of samples
-  real y[n];
+  array[n] real y;
 
   // priors
-  int<lower=0> p_ids[3];
-  real p_values[6];
+  array[3] int<lower=0> p_ids;
+  array[6] real p_values;
 }
 
 parameters {


### PR DESCRIPTION


Now that rstan 2.26 is available on CRAN we need to update your package's Stan models to use the new array syntax, otherwise it will fail to install with an upcoming version of RStan. If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
